### PR TITLE
Fix deploy problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<!-- Use this if database had deployed -->
 			<plugin>
 				<groupId>org.jooq</groupId>
 				<artifactId>jooq-codegen-maven</artifactId>
@@ -112,7 +113,7 @@
 				<configuration>
 					<jdbc>
 						<driver>org.postgresql.Driver</driver>
-						<url>jdbc:postgresql://192.168.195.198:5433/shopping_db</url>
+						<url>jdbc:postgresql://localhost:5433/shopping_db</url>
 						<user>postgres</user>
 						<password>123</password>
 					</jdbc>
@@ -132,6 +133,55 @@
 					</generator>
 				</configuration>
 			</plugin>
+			<!-- /Use this if database had deployed -->
+			<!-- Use this if first time deploy database to docker-->
+<!--			<plugin>-->
+<!--				<groupId>org.jooq</groupId>-->
+<!--				<artifactId>jooq-codegen-maven</artifactId>-->
+<!--				<version>3.18.0</version> &lt;!&ndash; 使用你需要的 jOOQ 版本 &ndash;&gt;-->
+<!--				<executions>-->
+<!--					<execution>-->
+<!--						<goals>-->
+<!--							<goal>generate</goal>-->
+<!--						</goals>-->
+<!--					</execution>-->
+<!--				</executions>-->
+<!--				<configuration>-->
+<!--					<jdbc>-->
+<!--						<driver>org.h2.Driver</driver>-->
+<!--						<url>jdbc:h2:mem:testdb;INIT=RUNSCRIPT FROM 'src/main/resources/db/h2-schema.sql'</url>-->
+<!--						<user>sa</user>-->
+<!--						<password></password>-->
+<!--					</jdbc>-->
+<!--					<generator>-->
+<!--						<database>-->
+<!--							<name>org.jooq.meta.h2.H2Database</name>-->
+<!--							<inputSchema>PUBLIC</inputSchema>-->
+<!--						</database>-->
+<!--						<generate>-->
+<!--							<pojos>true</pojos>-->
+<!--							<daos>true</daos>-->
+<!--						</generate>-->
+<!--						<target>-->
+<!--							<packageName>com.clothingstore.shop.jooq</packageName>-->
+<!--							<directory>target/generated-sources/jooq</directory>-->
+<!--						</target>-->
+<!--					</generator>-->
+<!--				</configuration>-->
+<!--				<dependencies>-->
+<!--					<dependency>-->
+<!--						<groupId>com.h2database</groupId>-->
+<!--						<artifactId>h2</artifactId>-->
+<!--						<version>2.2.220</version> &lt;!&ndash; 使用 H2 的适当版本 &ndash;&gt;-->
+<!--					</dependency>-->
+<!--					<dependency>-->
+<!--						<groupId>org.postgresql</groupId>-->
+<!--						<artifactId>postgresql</artifactId>-->
+<!--						<version>42.6.0</version> &lt;!&ndash; 如果需要生成与 PostgreSQL 兼容的代码，可以引入 PostgreSQL 驱动 &ndash;&gt;-->
+<!--					</dependency>-->
+<!--				</dependencies>-->
+<!--			</plugin>-->
+			<!-- /Use this if first time deploy database to docker-->
 		</plugins>
 		<finalName>clothing-shop</finalName>
 	</build>

--- a/src/main/java/com/clothingstore/shop/service/AuthService.java
+++ b/src/main/java/com/clothingstore/shop/service/AuthService.java
@@ -21,7 +21,7 @@ public class AuthService {
     public String authenticate(String username, String password, String role) {
         var user = authRepository.findByUserAccount(username);
         if(user.isPresent()){
-            if(user.get().getPassword().equals(password)){
+            if(user.get().getPassword().equals(password) && user.get().getUserType().equals(role) && !user.get().getIsDisable()){
                 return jwtService.generateJwtToken(username,role);
             }else {
                 return null;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,2 @@
 spring.application.name=clothing-shop
 
-# PostgreSQL Database Connection
-spring.datasource.url=jdbc:postgresql://192.168.195.198:5433/shopping_db
-spring.datasource.username=postgres
-spring.datasource.password=123
-spring.datasource.driver-class-name=org.postgresql.Driver
-
-# jOOQ SQL dialect
-spring.jooq.sql-dialect=POSTGRES

--- a/src/main/resources/db/changelog/tables/changelog-tables-user.yaml
+++ b/src/main/resources/db/changelog/tables/changelog-tables-user.yaml
@@ -48,5 +48,5 @@ databaseChangeLog:
         - addDefaultValue:
             tableName: users
             columnName: is_disable
-            defaultValueBoolean: true
+            defaultValueBoolean: false
 

--- a/src/main/resources/db/h2-schema.sql
+++ b/src/main/resources/db/h2-schema.sql
@@ -1,0 +1,15 @@
+CREATE TABLE users (
+    id BIGSERIAL PRIMARY KEY,
+    account VARCHAR(50) NOT NULL,
+    password VARCHAR(50) NOT NULL,
+    email VARCHAR(200) NOT NULL,
+    is_disable BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+
+ALTER TABLE users
+ADD COLUMN user_type VARCHAR(20) NOT NULL
+    CHECK (user_type IN ('admin', 'customer', 'vendor'));
+
+ALTER TABLE users
+ALTER COLUMN is_disable SET DEFAULT FALSE;


### PR DESCRIPTION
If Docker has a database, Liquibase must be used to avoid logical errors.
If there's no database, H2 should be used to prevent compilation errors. 
If jOOQ cannot find a database, Spring Boot will fail to compile, which in turn will prevent the deployment of the database. Therefore, H2 is used as a temporary substitute.